### PR TITLE
Add timeout support for requests

### DIFF
--- a/kismet_rest/__init__.py
+++ b/kismet_rest/__init__.py
@@ -14,6 +14,7 @@ from .base_interface import BaseInterface  # NOQA
 from .datasources import Datasources  # NOQA
 from .devices import Devices  # NOQA
 from .gps import GPS  # NOQA
+from .kismetdb import Logger  # NOQA
 from .logger import Logger  # NOQA
 from .legacy import KismetConnector  # NOQA
 from .messages import Messages  # NOQA

--- a/kismet_rest/base_interface.py
+++ b/kismet_rest/base_interface.py
@@ -44,10 +44,17 @@ class BaseInterface(object):
         session_cache (str): Path for storing session cache information.
             Defaults to `~/.pykismet_session`.
         debug (bool): Set to True to enble debug logging.
+        apikey (str): API token for interaction with Kismet REST interface.
+        timeout (int or tuple): Number of seconds Requests will wait for your 
+            client to establish a connection to a remote machine, or wait for 
+            the server to send a response. By default, requests do not time out 
+            unless a timeout value is set explicitly. Without a timeout, your 
+            code may hang for minutes or more. See requests documentation for 
+            more information. 
     """
 
     permitted_kwargs = ["host_uri", "username", "password",
-                        "session_cache", "debug", "apikey"]
+                        "session_cache", "debug", "apikey", "timeout"]
 
     def __init__(self, host_uri='http://127.0.0.1:2501',
                  sessioncache_path='~/.pykismet_session', **kwargs):
@@ -55,6 +62,7 @@ class BaseInterface(object):
         self.logger = Logger()
         self.max_retries = 5
         self.retry_statuses = [500]
+        self.timeout = None
         self.host_uri = host_uri
         self.username = None
         self.password = "nopass"
@@ -143,7 +151,7 @@ class BaseInterface(object):
         if verb == "GET":
             self.logger.debug("interact: GET against {} "
                               "stream={}".format(full_url, stream))
-            response = self.session.get(full_url, stream=stream)
+            response = self.session.get(full_url, stream=stream, timeout=self.timeout)
         elif verb == "POST":
             if payload:
                 postdata = json.dumps(payload)
@@ -156,7 +164,7 @@ class BaseInterface(object):
                                                          formatted_payload,
                                                          stream))
             response = self.session.post(full_url, data=formatted_payload,
-                                         stream=stream)
+                                         stream=stream, timeout=self.timeout)
 
         else:
             self.logger.error("HTTP verb {} not yet supported!".format(verb))
@@ -215,7 +223,7 @@ class BaseInterface(object):
         full_url = Utility.build_full_url(self.host_uri, url_path)
         if verb == "GET":
             self.logger.debug("interact_yield: GET {}".format(full_url))
-            response = self.session.get(full_url, stream=True)
+            response = self.session.get(full_url, stream=True, timeout=self.timeout)
         elif verb == "POST":
             if payload:
                 postdata = json.dumps(payload)
@@ -226,7 +234,7 @@ class BaseInterface(object):
             self.logger.debug("interact_yield: POST against {} "
                               "with {}".format(full_url, formatted_payload))
             response = self.session.post(full_url, data=formatted_payload,
-                                         stream=True)
+                                         stream=True, timeout=self.timeout)
 
         else:
             self.logger.error("HTTP verb {} not yet supported!".format(verb))
@@ -348,7 +356,7 @@ class BaseInterface(object):
 
         Checks if a session is valid / session is logged in
         """
-        response = self.session.get("%s/session/check_session" % self.host_uri)
+        response = self.session.get("%s/session/check_session" % self.host_uri, timeout=self.timeout)
         if not response.status_code == 200:
             return False
         self.update_session()
@@ -360,7 +368,7 @@ class BaseInterface(object):
         Logs in (and caches login credentials).  Required for administrative
         behavior.
         """
-        response = self.session.get("%s/session/check_session" % self.host_uri)
+        response = self.session.get("%s/session/check_session" % self.host_uri, timeout=self.timeout)
         if not response.status_code == 200:
             msg = "login(): Invalid session: {}".format(response.text)
             self.logger.debug(msg)

--- a/kismet_rest/base_interface.py
+++ b/kismet_rest/base_interface.py
@@ -146,6 +146,8 @@ class BaseInterface(object):
         """
         only_status = bool("only_status" in kwargs
                            and kwargs["only_status"] is True)
+        return_bytes = bool("return_bytes" in kwargs
+                           and kwargs["return_bytes"] is True)
         payload = kwargs["payload"] if "payload" in kwargs else {}
         full_url = Utility.build_full_url(self.host_uri, url_path)
         if verb == "GET":
@@ -197,6 +199,8 @@ class BaseInterface(object):
 
         if only_status:
             return bool(response)  # We can test for good resp codes like this.
+        if return_bytes:
+            return response.content
         if not stream:
             retval = self.process_response_bulk(response, **kwargs)
             self.update_session()

--- a/kismet_rest/kismetdb.py
+++ b/kismet_rest/kismetdb.py
@@ -26,7 +26,7 @@ class KismetDB(BaseInterface):
         query_args = self.kwargs_defaults.copy()
         query_args.update(kwargs)
         url = self.url_template.format(**query_args)
-        return self.interact("POST", url, payload=cmd)
+        return self.interact("POST", url, payload=cmd, return_bytes=True)
     
     def drop_packets(self, drop_before):
         """Dropping packets

--- a/kismet_rest/kismetdb.py
+++ b/kismet_rest/kismetdb.py
@@ -1,0 +1,45 @@
+"""KismetDB logs abstraction"""
+
+from .base_interface import BaseInterface
+
+
+class KismetDB(BaseInterface):
+    """KismetDB logs abstraction"""
+    
+    kwargs_defaults = {"title": "packets"}
+    url_template = "logging/kismetdb/pcap/{title}.pcapng"
+    
+    def packets(self, filter=None, **kwargs):
+        """Yield packets, one at a time.
+        
+        If callback is set, nothing will be returned.
+        
+        Keyword args:
+            title (str): File download title, does not impact pcap file generation.
+        
+        Yield:
+            bytes: A pcapng stream will be generated of packets, if any, matching the filter options.
+        """
+        cmd = {}
+        if filter:
+            cmd["filter"] = filter
+        query_args = self.kwargs_defaults.copy()
+        query_args.update(kwargs)
+        url = self.url_template.format(**query_args)
+        return self.interact("POST", url, payload=cmd)
+    
+    def drop_packets(self, drop_before):
+        """Dropping packets
+        
+        On very long-running Kismet processes, you may wish to purge old packets. 
+        These packets will be removed from the kismetdb log.
+        
+        Args:
+            drop_before (int): A unix second timestamp value, packets older than drop_before will be deleted.
+        
+        Return:
+            bool: True for success, False for failed request
+        """
+        cmd = {"drop_before": drop_before}
+        url = "logging/kismetdb/pcap/drop.cmd"
+        return self.interact("POST", url, payload=cmd, only_status=True)


### PR DESCRIPTION
Keep current behavior by default; requests do not time out, which can cause code to hang. Requests recommends setting to a multiple of 3.  See https://docs.python-requests.org/en/latest/user/advanced/#timeouts

Added apikey description in BaseInterface docstring.